### PR TITLE
Docker build: Include missing dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apk update && \
     wget \
     xdg-utils \
     xvfb \
-    xz
+    xz \
+    libxcomposite
 
 RUN  wget -O- ${CALIBRE_INSTALLER_SOURCE_CODE_URL} | python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); exec(sys.stdin.read()); main(install_dir='/opt', isolated=True)" && \
      rm -rf /tmp/calibre-installer-cache


### PR DESCRIPTION
By including the missing library https://github.com/lmorel3/calibre-alpine/issues/1 would be resolved.